### PR TITLE
Created Withdraw function on the solidity contract

### DIFF
--- a/hardhat-tutorial/contracts/CryptoDevToken.sol
+++ b/hardhat-tutorial/contracts/CryptoDevToken.sol
@@ -75,6 +75,14 @@ contract CryptoDevToken is ERC20, Ownable {
         _mint(msg.sender, amount * tokensPerNFT);
     }
 
+    // Enables withdrawal of ether sent to contract for ICO
+    function withdraw() public onlyOwner {
+        address _owner = owner();
+        uint256 amount = address(this).balance;
+        (bool sent, ) = _owner.call{value: amount}("");
+        require(sent, "Failed to send Ether");
+    }
+
     // Function to receive Ether. msg.data must be empty
     receive() external payable {}
 


### PR DESCRIPTION
ETH sent to the contract for the ICO is permanently stuck in the contract without the withdraw function.

The withdraw function enables the owner to withdraw all ETH and tokens sent to the contract.

Here, this function can be called from the front-end when the owner's wallet is connected