### PR TITLE
Error in contract instance name in getOwner function in index.js 

### DIFF
--- a/my-app/pages/index.js
+++ b/my-app/pages/index.js
@@ -228,7 +228,7 @@ export default function Home() {
   const getOwner = async () => {
     try {
       const provider = await getProviderOrSigner();
-      const nftContract = new Contract(TOKEN_CONTRACT_ADDRESS, TOKEN_CONTRACT_ABI, provider);
+      const tokenContract = new Contract(TOKEN_CONTRACT_ADDRESS, TOKEN_CONTRACT_ABI, provider);
       // call the owner function from the contract
       const _owner = await tokenContract.owner();
       // we get signer to extract address of currently connected Metamask account


### PR DESCRIPTION
In the index.js file of my app folder, the getOwner function initializes the instance of the contract as 

```solidity
const nftContract = new Contract(TOKEN_CONTRACT_ADDRESS, TOKEN_CONTRACT_ABI, provider);
const _owner = await tokenContract.owner();
```

I think the contract name should be 

```solidity
const tokenContract = new Contract(TOKEN_CONTRACT_ADDRESS, TOKEN_CONTRACT_ABI, provider);
const _owner = await tokenContract.owner();
```
